### PR TITLE
Docker multistage build + go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-	# Build stage
+# Build stage
 FROM golang AS build
 ADD . /src
 RUN apt-get update -yq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Build stage
+FROM golang:alpine AS build-env
+ADD . /go/src/github.com/tealeg/FootballPredictionGame
+RUN go version
+RUN cd /go/src/github.com/tealeg/FootballPredictionGame && go build -o fpg
+
+# Final stage
+FROM alpine
+WORKDIR /app
+COPY --from=build-env /go/src/github.com/tealeg/FootballPredictionGame/fpg /app/
+ENTRYPOINT ./fpg

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update -yq \
     && apt-get install nodejs -yq
 RUN cd /src && CGO_ENABLED=0 go build -o fpg
 RUN cd /src/static && npm install && npm run-script build
-RUN ls /src
 
 # Final stage
 FROM alpine

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/tealeg/FootballPredictionGame
+
+require (
+	github.com/coreos/bbolt v1.3.0
+	github.com/labstack/echo v3.2.1+incompatible
+	github.com/labstack/gommon v0.2.7 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
+	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4 // indirect
+)


### PR DESCRIPTION
This PR sets up a docker multistage build to east deployment and testing.

As the docker build requires some formal dependency management I also introduced the use of go modules.  This adds the following constraints:

- You must build with >= go1.11
- You must build outside of `$GOPATH`

Neither of these things should be an issue if you build using docker.