### PR TITLE
Redirect to routable URL instead of REST service URL for new league

### DIFF
--- a/static/src/views/AddLeagueForm.js
+++ b/static/src/views/AddLeagueForm.js
@@ -11,7 +11,7 @@ var AddLeagueForm = {
 			 e.preventDefault()
 			 Leagues.save().then(
 			     function(response) {
-				 window.location.href = "/league/" + response.ObjID
+				 window.location.href = "/#!/league/" + response.ObjID
 			     }
 			 ).catch(secure).catch(
 			     function(err) {


### PR DESCRIPTION
The old redirect pointed to a URL that is handled by the back-end REST services, instead of one that is routable in the single page application.