### PR TITLE
Fix tests that should now post JSON instead of forms.

### DIFF
--- a/app/league.go
+++ b/app/league.go
@@ -12,7 +12,7 @@ import (
 
 // newLeagueRequest is a holder for data passed into new League requests.
 type newLeagueRequest struct {
-	Name string
+	Name string `json:"name"`
 }
 
 // Validate checks the members of a newLeagueRequest for validity and
@@ -57,7 +57,7 @@ func makeNewLeagueHandler(e *echo.Echo, cdb *competition.DB) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		r.ObjID = strconv.FormatUint(lid, 10)
-		e.Logger.Info("User created: %+v", r)
+		e.Logger.Info("League created: %+v", r)
 		return c.JSON(http.StatusOK, r)
 	}
 }

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -209,7 +209,19 @@ func TestCreateAccountHandler(t *testing.T) {
 	h := makeCreateAccountHandler(e, adb)
 	err = h(c)
 	assert.NoError(t, err)
-	// TODO - maybe test that we actually create something?
+
+	exists, err := adb.AdminUserExists()
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	acc, err := adb.Get("bobit")
+	assert.NoError(t, err)
+	assert.NotNil(t, acc)
+	assert.Equal(t, "bob", acc.Forename)
+	assert.Equal(t, "bobfrey", acc.Surname)
+	assert.Equal(t, "bobit", acc.Name)
+	assert.Equal(t, HashPassword("lorena"), acc.HashedPassword)
+	assert.True(t, acc.IsAdmin)
 }
 
 // The returned createAccountHandler returns a list of validation errors

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/labstack/gommon v0.2.7 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/nsf/gocode v0.0.0-20180902125341-7b1d4e18cdc5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 	github.com/valyala/bytebufferpool v1.0.0 // indirect


### PR DESCRIPTION
Some tests used to test handlers that accepted HTML Form content but now should test handlers that accept JSON payloads.  One was failing, the other was not, but was not actually testing that it resulted in the right actions with regard to the DB.